### PR TITLE
In i2c_read() check endTransmission() and requestFrom() to ensure data returned is valid

### DIFF
--- a/src/CG_RadSens.cpp
+++ b/src/CG_RadSens.cpp
@@ -303,8 +303,9 @@ bool CG_RadSens::i2c_read(uint8_t RegAddr, uint8_t *dest, uint8_t num)
 #if defined(ARDUINO)
     Wire.beginTransmission(_sensor_address);
     Wire.write(RegAddr);
-    Wire.endTransmission();
-    if (Wire.requestFrom(_sensor_address, num))
+    if (Wire.endTransmission() != 0)
+        return false;
+    if (Wire.requestFrom(_sensor_address, num) == num)
     {
         for (int i = 0; i < num; i++)
             dest[i] = Wire.read();


### PR DESCRIPTION
I believe this change addresses issues like #10 and [maaad/RadSens1v2/issues/3](https://github.com/maaad/RadSens1v2/issues/3) where i2c communications issues were not detected and therefore erroneous values were returned to the caller. 

1) As documented here [Arduino Wire endTransmission() documentation](https://www.arduino.cc/reference/en/language/functions/communication/wire/endtransmission/) 
   endTransmission() returns 0 on success and other values on error.

   In the case of an error i2c_read() now returns false so callers do
   not try to interpret invalid data.

2) As documented here [Arduino Wire requestFrom() documentation](https://www.arduino.cc/reference/en/language/functions/communication/wire/requestfrom/)
   requestFrom() returns the number of bytes returned from the peripheral.
   
   In the case of fewer bytes returned than the number requested in
   i2c_read() return false to callers so they do not try to interpret
   invalid data.