### PR TITLE
Feature: Add getNumberOfNewPulses() and resetPulses() methods

### DIFF
--- a/src/CG_RadSens.cpp
+++ b/src/CG_RadSens.cpp
@@ -83,7 +83,8 @@ void CG_RadSens::updatePulses()
     uint8_t res[2];
     if (i2c_read(RS_PULSE_COUNTER_RG, res, 2))
     {
-        _pulse_cnt += (res[0] << 8) | res[1];
+        _new_cnt = (res[0] << 8) | res[1];
+        _pulse_cnt += _new_cnt;
     }
 }
 
@@ -93,6 +94,19 @@ uint32_t CG_RadSens::getNumberOfPulses()
 {
     updatePulses();
     return _pulse_cnt;
+}
+
+/*Get current number of pulses*/
+uint32_t CG_RadSens::getNumberOfNewPulses()
+{
+    updatePulses();
+    return _new_cnt;
+}
+
+/*Reset accumulated count*/
+void CG_RadSens::resetPulses()
+{
+    _pulse_cnt = 0;
 }
 
 /*Get sensor address.*/

--- a/src/CG_RadSens.h
+++ b/src/CG_RadSens.h
@@ -88,6 +88,7 @@ private:
     uint8_t _chip_id = 0;
     uint8_t _firmware_ver = 0;
     uint32_t _pulse_cnt = 0;
+    uint32_t _new_cnt = 0;
     bool i2c_read(uint8_t RegAddr, uint8_t *dest, uint8_t num);
     void updatePulses();
 
@@ -100,6 +101,8 @@ public:
     float getRadIntensyDynamic();
     float getRadIntensyStatic();
     uint32_t getNumberOfPulses();
+    uint32_t getNumberOfNewPulses();
+    void resetPulses();
     uint8_t getSensorAddress();
     bool getHVGeneratorState();
     bool getLedState();


### PR DESCRIPTION
Resolves #15 

Features:
- Add `getNumberOfNewPulses()` to get the number of pulses since the last read (either getNumberOfPulses() or getNumberOfNewPulses()).
- Add `resetPulses()` to reset the incremental pulse-count accumulated in the library.

Both methods only work on local variables, they do not change anything in the counter module.